### PR TITLE
Add example DLL call monitor

### DIFF
--- a/dll_monitor/Makefile
+++ b/dll_monitor/Makefile
@@ -1,0 +1,12 @@
+CC=x86_64-w64-mingw32-gcc
+CFLAGS=-Wall -Wextra -O2
+
+all: original.dll monitor.dll app.exe
+
+original.dll: original.c original.h ; $(CC) $(CFLAGS) -shared -o $@ original.c
+
+monitor.dll: monitor.c original.h ; $(CC) $(CFLAGS) -shared -o $@ monitor.c -L. -loriginal
+
+app.exe: app.c original.h monitor.dll ; $(CC) $(CFLAGS) -o $@ app.c -L. -lmonitor
+
+clean: ; rm -f *.o *.dll *.exe

--- a/dll_monitor/README.md
+++ b/dll_monitor/README.md
@@ -1,0 +1,21 @@
+# DLL Monitor Example
+
+This directory shows how to monitor calls from an executable to a DLL by using a proxy library.
+
+## Building
+
+This example targets Windows and requires the `mingw-w64` toolchain.
+
+```bash
+make
+```
+
+This will build:
+
+- `original.dll` – the real library with an `add` function.
+- `monitor.dll` – a proxy DLL that logs calls to `add` and forwards them to `original.dll`.
+- `app.exe` – a tiny program that links against `monitor.dll` and calls the `add` function.
+
+## Running
+
+Place `original.dll`, `monitor.dll`, and `app.exe` in the same directory and run `app.exe`. The console output shows the monitored calls.

--- a/dll_monitor/app.c
+++ b/dll_monitor/app.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include "original.h"
+
+int main(void) {
+    int r = add(2, 3);
+    printf("[app] add returned %d\n", r);
+    return 0;
+}

--- a/dll_monitor/monitor.c
+++ b/dll_monitor/monitor.c
@@ -1,0 +1,32 @@
+#include <windows.h>
+#include <stdio.h>
+#include "original.h"
+
+typedef int (__cdecl *ADD_FUNC)(int, int);
+
+static HMODULE real_dll = NULL;
+static ADD_FUNC real_add = NULL;
+
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
+    if (fdwReason == DLL_PROCESS_ATTACH) {
+        real_dll = LoadLibraryA("original.dll");
+        if (real_dll) {
+            real_add = (ADD_FUNC)GetProcAddress(real_dll, "add");
+        }
+    } else if (fdwReason == DLL_PROCESS_DETACH) {
+        if (real_dll) {
+            FreeLibrary(real_dll);
+        }
+    }
+    return TRUE;
+}
+
+__declspec(dllexport) int add(int a, int b) {
+    printf("[monitor] add(%d, %d)\n", a, b);
+    if (real_add) {
+        int result = real_add(a, b);
+        printf("[monitor] result=%d\n", result);
+        return result;
+    }
+    return 0;
+}

--- a/dll_monitor/original.c
+++ b/dll_monitor/original.c
@@ -1,0 +1,5 @@
+#include "original.h"
+
+int add(int a, int b) {
+    return a + b;
+}

--- a/dll_monitor/original.h
+++ b/dll_monitor/original.h
@@ -1,0 +1,14 @@
+#ifndef ORIGINAL_H
+#define ORIGINAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__declspec(dllexport) int add(int a, int b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ORIGINAL_H


### PR DESCRIPTION
## Summary
- add example original DLL with simple `add` function
- implement proxy DLL that logs calls before forwarding to original
- include small app and build instructions demonstrating call monitoring

## Testing
- `cd dll_monitor && make` *(fails: `x86_64-w64-mingw32-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2d4ebaac832ba591f65254201ba0